### PR TITLE
fix for last fix - ZORO the masked avenger [0,0] 

### DIFF
--- a/lib/download.js
+++ b/lib/download.js
@@ -297,6 +297,8 @@ function downloadGTFS(task, cb){
               (agency_bounds.ne[0] - agency_bounds.sw[0])/2 + agency_bounds.sw[0]
             , (agency_bounds.ne[1] - agency_bounds.sw[1])/2 + agency_bounds.sw[1]
           ];
+        }else{
+          var agency_center = [0,0];
         }
         Agency.update(
             {agency_key: agency_key}


### PR DESCRIPTION
"Fix for a bug introduced by the last fix for when agency_bounds where not defined.  It caused there not to be center for the agency to be placed. Now it will be set to [0,0] if agency_bounds is undefined."
