### PR TITLE
Fixing syntax error in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     , "async": ">= 0.2.x"
     , "request": ">= 2.14.x"
     , "underscore": ">= 1.4.4"
-	, "unzip": ">= "0.1.7"
+	, "unzip": ">= 0.1.7"
   },
   "scripts": {
     "download": "node scripts/download.js"


### PR DESCRIPTION
Pull request #8 left a bad `"` in the `package.json`, which this pull request fixes.
