### PR TITLE
Add support for GTFS shapes

### DIFF
--- a/examples/express/routes.js
+++ b/examples/express/routes.js
@@ -49,7 +49,23 @@ module.exports = function routes(app){
       res.send( data || {error: 'No routes within default radius'});
     });
   });
-  
+
+  //Shapes
+  app.get('/api/shapes/:agency/:route_id/:direction_id', function(req, res){
+    var agency_key = req.params.agency
+      , route_id = req.params.route_id
+      , direction_id = parseInt(req.params.direction_id,10);
+    gtfs.getShapesByRoute(agency_key, route_id, direction_id, function(e, data){
+      res.send( data || {error: 'No shapes for agency/route/direction combination.'});
+    });
+  });
+  app.get('/api/shapes/:agency/:route_id', function(req, res){
+    var agency_key = req.params.agency
+      , route_id = req.params.route_id
+    gtfs.getShapesByRoute(agency_key, route_id, function(e, data){
+      res.send( data || {error: 'No shapes for agency/route combination.'});
+    });
+  });
   
   //Stoplist
   app.get('/api/stops/:agency/:route_id/:direction_id', function(req, res){

--- a/lib/gtfs.js
+++ b/lib/gtfs.js
@@ -20,6 +20,7 @@ require('../models/FareRule');
 require('../models/FeedInfo');
 require('../models/Frequencies');
 require('../models/Route');
+require('../models/Shape');
 require('../models/Stop');
 require('../models/StopTime');
 require('../models/Transfer');
@@ -28,6 +29,7 @@ require('../models/Trip');
 var Agency = db.model('Agency')
   , Calendar = db.model('Calendar')
   , Route = db.model('Route')
+  , Shape = db.model('Shape')
   , Stop = db.model('Stop')
   , StopTime = db.model('StopTime')
   , Trip = db.model('Trip')
@@ -441,7 +443,63 @@ module.exports = {
           cb(ret);
         });
       });
+    },
+
+  getShapesByRoute: function(agency_key, route_id, direction_id, cb) {
+    if (_.isFunction(direction_id)) {
+      cb = direction_id;
+      direction_id = null;
     }
+    
+    var shape_ids = [];
+    var shapes = [];
+
+    async.series([getShapeIds, getShapes], function(err, result) {
+      cb(null, shapes);
+    });
+
+    function getShapeIds(cb) {   
+      var query = {
+        agency_key: agency_key,
+        route_id: route_id
+      }
+      
+      if ((direction_id === 0) || (direction_id === 1)) {
+        query.direction_id = direction_id;
+      } else {
+        query["$or"] = [{direction_id:0},{direction_id:1}]
+      }   
+      
+      Trip
+        .find(query)
+        .distinct('shape_id', function(err, results) {
+          if (results.length) {
+            shape_ids = results;
+            cb(null, 'shape_ids');
+          } else {
+            cb(new Error('No trips with shapes.'), 'trips')
+          }
+        });
+    }
+
+    function getShapes(cb) {
+      async.forEach(shape_ids, function(shape_id, cb) {
+        Shape.find({
+          agency_key: agency_key,
+          shape_id: parseInt(shape_id, 10),
+        }, function(err, shape_pts) {
+          if(shape_pts.length) {
+            shapes.push(shape_pts);
+            cb(null, 'shape_pts');
+          } else {
+            cb(new Error('No shapes with shape_id.'), 'shape_pts')
+          }
+        });
+      }, function(err) {
+        cb(null, 'shapes');
+      })
+    }
+  }
 };
 
 function handleError(e) {

--- a/scripts/download.js
+++ b/scripts/download.js
@@ -51,6 +51,10 @@ var GTFSFiles = [
     , collection: 'routes'
   },
   {
+      fileNameBase: 'shapes'
+    , collection: 'shapes'
+  },
+  {
       fileNameBase: 'stop_times'
     , collection: 'stoptimes'
   },
@@ -199,8 +203,11 @@ Db.connect(config.mongo_url, {w: 1}, function(err, db) {
                 if(line.direction_id){
                   line.direction_id = parseInt(line.direction_id, 10);
                 }
+                if(line.shape_pt_sequence){
+                  line.shape_pt_sequence = parseInt(line.shape_pt_sequence, 10);
+                }
 
-                //make lat/lon array
+                //make lat/lon array for stops
                 if(line.stop_lat && line.stop_lon){
                   line.loc = [parseFloat(line.stop_lon), parseFloat(line.stop_lat)];
                   
@@ -217,6 +224,13 @@ Db.connect(config.mongo_url, {w: 1}, function(err, db) {
                   if(agency_bounds.ne[1] < line.loc[1] || !agency_bounds.ne[1]){
                     agency_bounds.ne[1] = line.loc[1];
                   }
+                }
+
+                //make lat/long for shapes
+                if(line.shape_pt_lat && line.shape_pt_lon){
+                  line.shape_pt_lon = parseFloat(line.shape_pt_lon)
+                  line.shape_pt_lat = parseFloat(line.shape_pt_lat)
+                  line.loc = [line.shape_pt_lon, line.shape_pt_lat];
                 }
 
                 //insert into db


### PR DESCRIPTION
This adds support for reading and querying the shape file that is often included with GTFS.

Useful for times when you want to display a transit line's path instead of just the stops.
