### PR TITLE
Remove redundant heroku step.

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,6 @@ Add MongoHQ to your app
 
 MONGOHQ creates a user, database and exports it as a MONGOHQ_URL environment variable.
 
-Add Heroku as a remote repo:
-
-    $ git remote add heroku git@heroku.com:YOUR_APP_NAME.git
-
 Push your app to Heroku
 
     $ git push heroku master


### PR DESCRIPTION
The `heroku apps:create` command automatically adds the git remote, so this step is redundant and will just yield, `fatal: remote heroku already exists`.
