### PR TITLE
Fix csv files not being parsed

### DIFF
--- a/scripts/download.js
+++ b/scripts/download.js
@@ -211,7 +211,7 @@ Db.connect(config.mongo_url, {w: 1}, function(err, db) {
         log(agency_key + ': Importing data - ' + GTFSFile.fileNameBase);
         db.collection(GTFSFile.collection, function(e, collection){
           var input = fs.createReadStream(filepath);
-          var parser = csv.parse({columns: true});
+          var parser = csv.parse({columns: true, relax: true});
           parser.on('readable', function(){
             while(line = parser.read()){
               //remove null values


### PR DESCRIPTION
The following line now can be parsed correctly, without erros caused by the quotes:
```
533,12,C,Rsa "S.Bartolomeo" Rsa "Angeli Custodi",3,000000,FFFFFF
```