### PR TITLE
Add agency id option - issue #40

### DIFF
--- a/lib/gtfs.js
+++ b/lib/gtfs.js
@@ -100,12 +100,24 @@ module.exports = {
 
 
   /*
-   * Returns an array of routes for the `agency_key` specified
+   * Returns an array of routes for the `agency_key` specified and `agency_id` if specified
    */
-  getRoutesByAgency: function(agency_key, cb) {
-    Route.find({
-      agency_key: agency_key
-    }, cb);
+  getRoutesByAgency: function(agency_key, agency_id, cb) {
+  	if(_.isFunction(agency_id)) {
+  	  cb = agency_id;
+  	  agency_id = null;  	
+  	}
+	
+  	if(agency_id === null) {
+      Route.find({
+        agency_key: agency_key
+      }, cb);
+	} else {
+	  Route.find({
+		agency_key: agency_key,
+		agency_id: agency_id
+	  }, cb);
+	}
   },
 
 

--- a/lib/gtfs.js
+++ b/lib/gtfs.js
@@ -70,7 +70,7 @@ module.exports = {
         agency_key: agency_key
       }, cb);
 	} else {
-      Agency.find({
+      Agency.findOne({
         agency_key: agency_key,
 		agency_id: agency_id
       }, cb);

--- a/lib/gtfs.js
+++ b/lib/gtfs.js
@@ -59,10 +59,22 @@ module.exports = {
   /*
    * Returns an agency
    */
-  getAgency: function(agency_key, cb) {
-    Agency.findOne({
-      agency_key: agency_key
-    }, cb);
+  getAgency: function(agency_key, agency_id, cb) {
+	if(_.isFunction(agency_id)) {
+	  cb = agency_id;
+	  agency_id = null;  	
+	}
+	
+	if(agency_id === null) {
+      Agency.findOne({
+        agency_key: agency_key
+      }, cb);
+	} else {
+      Agency.find({
+        agency_key: agency_key,
+		agency_id: agency_id
+      }, cb);
+	}
   },
 
 

--- a/test/mocha/lib/gtfs.getAgency.js
+++ b/test/mocha/lib/gtfs.getAgency.js
@@ -1,0 +1,178 @@
+// dependencies
+var request = require('supertest');
+var async = require('async');
+var should = require('should');
+var tk = require('timekeeper');
+var timeReference = new Date();
+
+// libraries
+var config = require('./../../config');
+var gtfs = require('./../../../');
+var downloadScript = require('../../../scripts/download');
+
+// test support
+var databaseTestSupport = require('./../../support/database')(config);
+var db;
+
+// setup fixtures
+var agenciesFixtures = [{ agency_key: 'caltrain', url: __dirname + '/../../fixture/caltrain_20120824_0333.zip'}];
+config.agencies = agenciesFixtures;
+
+describe('gtfs.getAgency(): ', function(){
+
+  before(function(done){
+    async.series({
+      connectToDb: function(next){
+        databaseTestSupport.connect(function(err, _db){
+          db = _db;
+          next();
+        });
+      },
+      setupMockDate: function(next){
+        tk.freeze(timeReference);
+        next();
+      }
+    }, function(){
+      done();
+    });
+  });
+
+  after(function(done) {
+    async.series({
+      teardownDatabase: function(next){
+        databaseTestSupport.teardown(next);
+      },
+      closeDb: function(next){
+        databaseTestSupport.close(next);
+      },
+      resetMockDate: function(next){
+        tk.reset();
+        next();
+      }
+    }, function(){
+      done();
+    });
+  });
+
+  beforeEach(function(done){
+    async.series({
+      teardownDatabase: function(next){
+        databaseTestSupport.teardown(next);
+      },
+      executeDownloadScript: function(next){
+        downloadScript(config, next);
+      }
+    }, function(err, res){
+      done();
+    });
+  });
+
+  it('should return null if agency_key does not exist (no agency_id provided)', function(done){
+    async.series({
+      teardownDatabase: function(next){
+        databaseTestSupport.teardown(next);
+      }
+    }, function(){
+	  var agency_key = 'caltrain-NOT';
+      gtfs.getAgency(agency_key, function(err, agencies) {
+        should.not.exists(err);
+        should.not.exists(agencies);
+		
+        done();
+      });
+    });
+  });
+
+  it('should return expected agency for agency_key (no agency_id provided)', function(done){
+	var agency_key = 'caltrain';
+    gtfs.getAgency(agency_key, function(err, agencies){
+      should.not.exist(err);
+      should.exist(agencies);
+
+      var agency = agencies.toObject();
+
+      agency.agency_key.should.equal('caltrain');
+      agency.agency_id.should.equal('caltrain-ca-us');
+      agency.agency_name.should.equal('Caltrain');
+      agency.agency_url.should.equal('http://www.caltrain.com');
+      agency.agency_timezone.should.equal('America/Los_Angeles');
+      agency.agency_lang.should.equal('en');
+      agency.agency_phone.should.equal('800-660-4287');
+
+      // current fixture does not have fare url. update this if needed next time
+      should.not.exist(agency.agency_fare_url);
+
+      agency.agency_bounds.should.have.keys(['sw', 'ne']);
+      agency.agency_bounds.sw.should.have.length(2);
+      agency.agency_bounds.sw[0].should.eql(-122.406408);
+      agency.agency_bounds.sw[1].should.eql(37.003084);
+      agency.agency_bounds.ne.should.have.length(2);
+      agency.agency_bounds.ne[0].should.eql(-121.567091);
+      agency.agency_bounds.ne[1].should.eql(37.7764393371);
+
+      agency.agency_center.should.have.length(2);
+      agency.agency_center[0].should.eql(-121.9867495);
+      agency.agency_center[1].should.eql(37.38976166855);
+
+      agency.date_last_updated.should.eql(timeReference.getTime());
+
+      done();
+    });
+  });
+
+  it('should return null if agency_key does not exist (agency_id provided)', function(done){
+    async.series({
+      teardownDatabase: function(next){
+        databaseTestSupport.teardown(next);
+      }
+    }, function(){
+	  var agency_key = 'caltrain-NOT';
+	  var agency_id = 'caltrain-ca-us';
+      gtfs.getAgency(agency_key, agency_id, function(err, agencies) {
+        should.not.exists(err);
+        should.not.exists(agencies);
+		
+        done();
+      });
+    });
+  });
+
+  it('should return expected agency for agency_key and agency_id', function(done){
+	var agency_key = 'caltrain';
+	var agency_id = 'caltrain-ca-us';
+    gtfs.getAgency(agency_key, agency_id, function(err, agencies){
+      should.not.exist(err);
+      should.exist(agencies);
+
+	  var agency = agencies.toObject();
+
+      agency.agency_key.should.equal('caltrain');
+      agency.agency_id.should.equal('caltrain-ca-us');
+      agency.agency_name.should.equal('Caltrain');
+      agency.agency_url.should.equal('http://www.caltrain.com');
+      agency.agency_timezone.should.equal('America/Los_Angeles');
+      agency.agency_lang.should.equal('en');
+      agency.agency_phone.should.equal('800-660-4287');
+
+      // current fixture does not have fare url. update this if needed next time
+      should.not.exist(agency.agency_fare_url);
+
+      agency.agency_bounds.should.have.keys(['sw', 'ne']);
+      agency.agency_bounds.sw.should.have.length(2);
+      agency.agency_bounds.sw[0].should.eql(-122.406408);
+      agency.agency_bounds.sw[1].should.eql(37.003084);
+      agency.agency_bounds.ne.should.have.length(2);
+      agency.agency_bounds.ne[0].should.eql(-121.567091);
+      agency.agency_bounds.ne[1].should.eql(37.7764393371);
+
+      agency.agency_center.should.have.length(2);
+      agency.agency_center[0].should.eql(-121.9867495);
+      agency.agency_center[1].should.eql(37.38976166855);
+
+      agency.date_last_updated.should.eql(timeReference.getTime());
+
+      done();
+    });
+  });
+  
+});

--- a/test/mocha/lib/gtfs.getRoutesByAgency.js
+++ b/test/mocha/lib/gtfs.getRoutesByAgency.js
@@ -65,7 +65,6 @@ describe('gtfs.getRoutesByAgency(): ', function(){
         databaseTestSupport.teardown(next);
       }
     }, function(){
-		console.log('1) agency_key: ' + agency_key);
       gtfs.getRoutesByAgency(agency_key, function(err, res){
         should.not.exist(err);
         should.exist(res);
@@ -76,7 +75,6 @@ describe('gtfs.getRoutesByAgency(): ', function(){
   });
 
   it('should return expected routes for given agency (agency_id not provided)', function(done){
-	console.log('2) agency_key: ' + agency_key);
     gtfs.getRoutesByAgency(agency_key, function(err, routes){
       should.not.exist(err);
       should.exist(routes);
@@ -179,7 +177,6 @@ describe('gtfs.getRoutesByAgency(): ', function(){
         databaseTestSupport.teardown(next);
       }
     }, function(){
-		console.log('3) agency_key: ' + agency_key + '\tagency_id: ' + agency_id);
       gtfs.getRoutesByAgency(agency_key, agency_id, function(err, res){
         should.not.exist(err);
         should.exist(res);
@@ -190,7 +187,6 @@ describe('gtfs.getRoutesByAgency(): ', function(){
   });
 
   it('should return expected routes for given agency and agency_id', function(done){
-	console.log('4) agency_key: ' + agency_key + '\tagency_id: ' + agency_id);
     gtfs.getRoutesByAgency(agency_key, agency_id, function(err, routes){
       should.not.exist(err);
       should.exist(routes);

--- a/test/mocha/lib/gtfs.getRoutesByAgency.js
+++ b/test/mocha/lib/gtfs.getRoutesByAgency.js
@@ -14,6 +14,7 @@ var db;
 // setup fixtures
 var agenciesFixtures = [{ agency_key: 'caltrain', url: __dirname + '/../../fixture/caltrain_20120824_0333.zip'}];
 var agency_key = agenciesFixtures[0].agency_key;
+var agency_id = agenciesFixtures[0].agency_id;
 
 config.agencies = agenciesFixtures;
 
@@ -58,12 +59,13 @@ describe('gtfs.getRoutesByAgency(): ', function(){
     });
   });
 
-  it('should return empty array if no routes for given agency exists', function(done){
+  it('should return empty array if no routes for given agency exists (agency_id not provided)', function(done){
     async.series({
       teardownDatabase: function(next){
         databaseTestSupport.teardown(next);
       }
     }, function(){
+		console.log('1) agency_key: ' + agency_key);
       gtfs.getRoutesByAgency(agency_key, function(err, res){
         should.not.exist(err);
         should.exist(res);
@@ -73,8 +75,123 @@ describe('gtfs.getRoutesByAgency(): ', function(){
     });
   });
 
-  it('should return expected routes for given agency', function(done){
-    gtfs.getRoutesByAgency(agency_key,function(err, routes){
+  it('should return expected routes for given agency (agency_id not provided)', function(done){
+	console.log('2) agency_key: ' + agency_key);
+    gtfs.getRoutesByAgency(agency_key, function(err, routes){
+      should.not.exist(err);
+      should.exist(routes);
+
+      var expectedRoutes = {
+        ct_bullet_20120701: {
+          route_id: 'ct_bullet_20120701',
+          route_short_name: '',
+          route_long_name: 'Bullet',
+          route_desc: '',
+          route_type: 2,
+          route_url: '',
+          route_color: 'E31837',
+          route_text_color: '',
+          agency_key: 'caltrain'
+        },
+        ct_limited_20120701: {
+          route_id: 'ct_limited_20120701',
+          route_short_name: '',
+          route_long_name: 'Limited',
+          route_desc: '',
+          route_type: 2,
+          route_url: '',
+          route_color: 'FEF0B5',
+          route_text_color: '',
+          agency_key: 'caltrain'
+        },
+        ct_local_20120701: {
+          route_id: 'ct_local_20120701',
+          route_short_name: '',
+          route_long_name: 'Local',
+          route_desc: '',
+          route_type: 2,
+          route_url: '',
+          route_color: '',
+          route_text_color: '',
+          agency_key: 'caltrain'
+        },
+        ct_bullet_20121001: {
+          route_id: 'ct_bullet_20121001',
+          route_short_name: '',
+          route_long_name: 'Bullet',
+          route_desc: '',
+          route_type: 2,
+          route_url: '',
+          route_color: 'E31837',
+          route_text_color: '',
+          agency_key: 'caltrain'
+        },
+        ct_limited_20121001: {
+          route_id: 'ct_limited_20121001',
+          route_short_name: '',
+          route_long_name: 'Limited',
+          route_desc: '',
+          route_type: 2,
+          route_url: '',
+          route_color: 'FEF0B5',
+          route_text_color: '',
+          agency_key: 'caltrain'
+        },
+        ct_local_20121001: {
+          route_id: 'ct_local_20121001',
+          route_short_name: '',
+          route_long_name: 'Local',
+          route_desc: '',
+          route_type: 2,
+          route_url: '',
+          route_color: '',
+          route_text_color: '',
+          agency_key: 'caltrain'
+        }
+      };
+
+      routes.should.have.length(6);
+
+      for (var i in routes){
+        var route = routes[i];
+        var expectedRoute = expectedRoutes[route.route_id];
+
+        should.exist(expectedRoute);
+        route.route_id.should.equal(expectedRoute.route_id);
+        route.route_short_name.should.equal(expectedRoute.route_short_name);
+        route.route_long_name.should.equal(expectedRoute.route_long_name);
+        route.route_desc.should.equal(expectedRoute.route_desc);
+        route.route_type.should.equal(expectedRoute.route_type);
+        route.route_long_name.should.equal(expectedRoute.route_long_name);
+        route.route_url.should.equal(expectedRoute.route_url);
+        route.route_color.should.equal(expectedRoute.route_color);
+        route.route_text_color.should.equal(expectedRoute.route_text_color);
+        route.agency_key.should.equal(expectedRoute.agency_key);
+      }
+
+      done();
+    });
+  });
+  
+  it('should return empty array if no routes for given agency exists (agency_id provided)', function(done){
+    async.series({
+      teardownDatabase: function(next){
+        databaseTestSupport.teardown(next);
+      }
+    }, function(){
+		console.log('3) agency_key: ' + agency_key + '\tagency_id: ' + agency_id);
+      gtfs.getRoutesByAgency(agency_key, agency_id, function(err, res){
+        should.not.exist(err);
+        should.exist(res);
+        res.should.have.length(0);
+        done();
+      });
+    });
+  });
+
+  it('should return expected routes for given agency and agency_id', function(done){
+	console.log('4) agency_key: ' + agency_key + '\tagency_id: ' + agency_id);
+    gtfs.getRoutesByAgency(agency_key, agency_id, function(err, routes){
       should.not.exist(err);
       should.exist(routes);
 


### PR DESCRIPTION
Added 'agency_id' parameter to `get_agency` and `getRoutesByAgency`. Also added appropriate tests to test suite.

Rather than provide a default value, a missing 'agency_id' is set to null. Then an if/else provides the appropriate action.