### PR TITLE
getStopsOnRoute bug fix

### DIFF
--- a/lib/gtfs.js
+++ b/lib/gtfs.js
@@ -318,7 +318,7 @@ module.exports = {
       // - specified (return stops for a direction)
       // - or not specified (return stops for all directions)
       var results = [];
-      if(direction_id) {
+      if (!direction_id) {
         results = stops[direction_id] || [];
       } else {
         _.each(stops, function(stops, direction_id) {


### PR DESCRIPTION
Was going into else block with a valid parameter. this was causing both direction_id's to be returned if only one was specified.