### PR TITLE
insert via chunks (out of memory error should not happen anymore)

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,9 +72,10 @@
   "dependencies": {
     "async": "1.5.2",
     "csv": "0.4.6",
+    "lodash": "^4.12.0",
     "mkdirp": "0.5.1",
-    "mongodb": "2.1.14",
-    "mongoose": "4.4.10",
+    "mongodb": "2.1.18",
+    "mongoose": "4.4.16",
     "proj4": "2.3.14",
     "request": "2.69.0",
     "rimraf": "2.5.2",

--- a/scripts/download.js
+++ b/scripts/download.js
@@ -12,6 +12,8 @@ var argv = require('yargs').argv;
 
 var filenames = require('../lib/filenames');
 
+var _ = require('lodash');
+
 var q;
 var config = {};
 // check if this file was invoked direct through command line or required as an export
@@ -34,6 +36,20 @@ if (invocation === 'direct') {
   }
 }
 
+/*
+ * Divides the given arr into chunks with the given max
+ * length. Returns a new array containing the chunks.
+ */
+function getChunks(arr, max) {
+  var chunksCount = parseInt(arr.length / max) + 1;
+
+  var chunks = [];
+  _.times(chunksCount, count => {
+    chunks.push(_.slice(arr, count * max, (count + 1) * max));
+  });
+
+  return chunks;
+}
 
 function main(config, callback) {
   var log = (config.verbose === false) ? function() {} : console.log;
@@ -217,6 +233,8 @@ function main(config, callback) {
               relax: true
             });
 
+            var lines = [];
+
             parser.on('readable', function() {
               while(line = parser.read()) {
                 //remove null values
@@ -328,17 +346,39 @@ function main(config, callback) {
                 if (line.shape_pt_lat && line.shape_pt_lon) {
                   line.loc = [line.shape_pt_lon, line.shape_pt_lat];
                 }
-
-                //insert into db
-                collection.insert(line, function(e) {
-                  if (e) {
-                    handleError(e);
-                  }
-                });
+                lines.push(line);
               }
             });
+
             parser.on('end', function() {
-              cb();
+              log('length of csv-array %d ' + filename.fileNameBase, lines.length);
+              var chunks = getChunks(lines, 10000);
+              log('length of csv-chunks %d ' + filename.fileNameBase, chunks.length);
+
+              // only insert 1 chunk at once in order to avoid an out-of-memory error
+              var queue = async.queue(function (chunk, callback) {
+                collection.insertMany(chunk, function(e) {
+                  if (e) {
+                    log('ERROR during mongo insertMany chunk ' + filename.fileNameBase);
+                    handleError(e);
+                    callback(e);
+                  }
+                  callback();
+                });
+              }, 1);
+
+              queue.drain = function () {
+                log('DRAIN all items have been processed from ' + filename.fileNameBase);
+                cb();
+              };
+
+              queue.push(chunks, function (err) {
+                if (err) {
+                  log('ERROR SINGLE CALLBACK item processing ' + filename.fileNameBase);
+                } else {
+                  // ignore we don't want to fill the screen with unnecessary information
+                }
+              });
             });
             parser.on('error', handleError);
             input.pipe(parser);


### PR DESCRIPTION
In order to avoid out-of-memory errors the insertion is divided into chunks (size 10,000).
Every chunk is then inserted one-by-one.

Tested with portland-trimed gtfs:  (30MB as zip, 220MB unzipped, duration: ~3min 20sec)

portland-trimet: Starting
portland-trimet: Importing data - agency.txt
length of csv-array 3 agency
length of csv-parts 1 agency
DRAIN all items have been processed from agency
portland-trimet: Importing data - calendar_dates.txt
length of csv-array 715 calendar_dates
length of csv-parts 1 calendar_dates
DRAIN all items have been processed from calendar_dates
portland-trimet: Importing data - No calendar.txt file found
portland-trimet: Importing data - fare_attributes.txt
length of csv-array 6 fare_attributes
length of csv-parts 1 fare_attributes
DRAIN all items have been processed from fare_attributes
portland-trimet: Importing data - fare_rules.txt
length of csv-array 18 fare_rules
length of csv-parts 1 fare_rules
DRAIN all items have been processed from fare_rules
portland-trimet: Importing data - feed_info.txt
length of csv-array 1 feed_info
length of csv-parts 1 feed_info
DRAIN all items have been processed from feed_info
portland-trimet: Importing data - No frequencies.txt file found
portland-trimet: Importing data - routes.txt
length of csv-array 90 routes
length of csv-parts 1 routes
DRAIN all items have been processed from routes
portland-trimet: Importing data - shapes.txt
length of csv-array 1108530 shapes
length of csv-parts 111 shapes
DRAIN all items have been processed from shapes
portland-trimet: Importing data - stop_times.txt
length of csv-array 2686388 stop_times
length of csv-parts 269 stop_times
DRAIN all items have been processed from stop_times
portland-trimet: Importing data - stops.txt
length of csv-array 6992 stops
length of csv-parts 1 stops
DRAIN all items have been processed from stops
portland-trimet: Importing data - transfers.txt
length of csv-array 3914 transfers
length of csv-parts 1 transfers
DRAIN all items have been processed from transfers
portland-trimet: Importing data - trips.txt
length of csv-array 49081 trips
length of csv-parts 5 trips
DRAIN all items have been processed from trips
portland-trimet: Post Processing data
portland-trimet: Completed
All agencies completed (1 total)
npm run download  143.66s user 1.95s system 71% cpu 3:23.07 total 