### PR TITLE
Fix: Changing _.conatins to the new funciton _.includes

### DIFF
--- a/lib/gtfs.js
+++ b/lib/gtfs.js
@@ -594,7 +594,7 @@ module.exports = {
       route_id: route_id
     };
 
-    if (_.contains([0, 1], direction_id)) {
+    if (_.includes([0, 1], direction_id)) {
       query.direction_id = direction_id;
     } else {
       query.direction_id = {


### PR DESCRIPTION
With the switch from underscore to lodash the _.contains function is no longer valid. The lodash function that does the same thing is named _.includes. I only found it one location and changed it to the new function name.