### PR TITLE
Added functionality for searching `stop_code`

### DIFF
--- a/lib/gtfs.js
+++ b/lib/gtfs.js
@@ -32,6 +32,7 @@ exports.getRoutesByDistance = routes.getRoutesByDistance;
 exports.getRoutesByStop = routes.getRoutesByStop;
 
 exports.getStops = stops.getStops;
+exports.getStopsByStopCode = stops.getStopsByStopCode;
 exports.getStopsByRoute = stops.getStopsByRoute;
 exports.getStopsByDistance = stops.getStopsByDistance;
 

--- a/lib/gtfs/stops.js
+++ b/lib/gtfs/stops.js
@@ -33,6 +33,33 @@ exports.getStops = (agency_key, stop_ids, cb) => {
   return Stop.find(query).exec(cb);
 };
 
+/*
+ * Returns an array of stops for the `agency_key` specified, optionally
+ * limited to the `stop_code` specified
+ */
+exports.getStopsByStopCode = (agency_key, stop_code, cb) => {
+  if (_.isFunction(stop_code)) {
+    cb = stop_code;
+    stop_code = undefined;
+  }
+
+  const query = {
+    agency_key
+  }
+
+  if (stop_code !== undefined) {
+    if (!_.isArray(stop_code)) {
+      stop_code = [stop_code];
+    }
+
+    query.stop_code = {
+      stop_code : stop_code
+    };
+  }
+
+  return Stop.find(query).exec(cb);
+};
+
 
 /*
  * Returns an array of stops along the `route_id` for the `agency_key` and `direction_id` specified

--- a/lib/gtfs/stops.js
+++ b/lib/gtfs/stops.js
@@ -53,7 +53,7 @@ exports.getStopsByStopCode = (agency_key, stop_code, cb) => {
     }
 
     query.stop_code = {
-      stop_code : stop_code
+      $in : stop_code
     };
   }
 

--- a/models/Stop.js
+++ b/models/Stop.js
@@ -9,7 +9,10 @@ const Stop = mongoose.model('Stop', new mongoose.Schema({
     type: String,
     index: true
   },
-  stop_code: String,
+  stop_code: {
+    type: String,
+    index: true
+  },
   stop_name: String,
   stop_desc: String,
   stop_lat: Number,

--- a/test/mocha/gtfs.getStopsByCode.js
+++ b/test/mocha/gtfs.getStopsByCode.js
@@ -1,0 +1,90 @@
+const async = require('async');
+const path = require('path');
+const should = require('should');
+
+// libraries
+const config = require('../config.json');
+const gtfs = require('../../');
+
+
+// test support
+const database = require('../support/database');
+
+// setup fixtures
+const agenciesFixtures = [{
+  agency_key: 'caltrain',
+  path: path.join(__dirname, '../fixture/caltrain_20160406.zip')
+}];
+
+config.agencies = agenciesFixtures;
+
+describe('gtfs.getStopsByStopCode(): ', () => {
+
+  before((done) => {
+    database.connect(config, done);
+  });
+
+  after((done) => {
+    async.series({
+      teardownDatabase: (next) => {
+        database.teardown(next);
+      },
+      closeDb: (next) => {
+        database.close(next);
+      }
+    }, done);
+  });
+
+  beforeEach((done) => {
+    async.series({
+      teardownDatabase: (next) => {
+        database.teardown(next);
+      },
+      executeDownloadScript: (next) => {
+        gtfs.import(config, next);
+      }
+    }, done);
+  });
+
+  it('should return an empty array if no stops exists for given agency', (done) => {
+    async.series({
+      teardownDatabase: (next) => {
+        database.teardown(next);
+      }
+    },() => {
+      const agency_key = 'non_existing_agency';
+      gtfs.getStops(agency_key, (err, stops) => {
+        should.exist(stops);
+        stops.should.have.length(0);
+        done();
+      });
+    });
+  });
+
+  it('should return array of stops if it exists for given agency', (done) => {
+    const agency_key = 'caltrain';
+
+    gtfs.getStopsByStopCode(agency_key, (err, stops) => {
+      should.not.exist(err);
+      should.exist(stops);
+
+      stops.should.have.length(95);
+      done();
+    });
+  });
+
+  it('should return array of stops if it exists for given agency, and stop_ids', (done) => {
+    const agency_key = 'caltrain';
+    const stop_codes = [
+      '70031',
+      '70061'
+    ];
+
+    gtfs.getStopsByStopCode(agency_key, stop_codes, (err, stops) => {
+      should.not.exist(err);
+      should.exist(stops);
+      stops.should.have.length(2);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
**Why is this needed?**
Unliked Caltrain (which it seems is your test data), New Jersey Transit does not align `stop_id` with `stop_code`. This means they end up being different numbers, hence querying one doesn't give you the same number. That means, for New Jersey, the stop number posted at the stop corresponds with the `stop_code` and not the `stop_id`.

-----

Because of this I have *attempted* to write a function that allows the querying of `stop_codes` based on the code that was already written. **Please note that this PR is not fully working and I would like some help debugging it**. This is my first time working on an node module, so while I understand *most* of what I am doing, I don't understand all of it. Namely, this function seems to hang when passed parameters (so... it doesn't quite work). I would like to get some feedback on where I have made a mistake, but other than that you can see where I was going with the idea.

Thanks again!