### PR TITLE
pass user agent and allow response.status 2xx

### DIFF
--- a/src/lib/import-gtfs.ts
+++ b/src/lib/import-gtfs.ts
@@ -100,13 +100,17 @@ const downloadGtfsFiles = async (task: GtfsImportTask): Promise<void> => {
   try {
     const response = await fetch(task.url, {
       method: 'GET',
-      headers: task.headers || {},
+      redirect: 'follow',
+      headers: {
+        'User-Agent': 'node-gtfs',
+        ...task.headers,
+      },
       signal: task.downloadTimeout
         ? AbortSignal.timeout(task.downloadTimeout)
         : undefined,
     });
 
-    if (response.status !== 200) {
+    if (!response.ok) {
       throw new GtfsError(
         `Unable to download GTFS from ${task.url}. Got status ${response.status}.`,
         {


### PR DESCRIPTION
## Fix GTFS URL download failures

Some GTFS URLs that work fine in a browser would fail silently when downloaded by node-gtfs. Two bugs in `downloadGtfsFiles` were responsible:

**1. Missing `User-Agent` header**
Node's `fetch` sends no `User-Agent` by default. Many transit agency servers (especially government ones) block or reject requests without one, while browsers succeed because they always identify themselves. A default `User-Agent: node-gtfs` header is now sent, with any user-supplied headers still taking precedence.

**2. `status !== 200` check was too strict**
Replaced with `!response.ok`, which correctly accepts any `2xx` response. Some servers return `206 Partial Content` or other valid success codes for file downloads, which the old check would incorrectly treat as errors.

Also added explicit `redirect: 'follow'` for clarity.

### Changes
- `src/lib/import-gtfs.ts`