### PR TITLE
Fix rt alert `informed_entities`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1529,7 +1529,7 @@ In order to use GTFS-Realtime query methods, you must first run the [GTFS-Realti
 
 #### getServiceAlerts(query, fields, sortBy, options)
 
-Returns an array of GTFS Realtime service alerts that match query parameters. Note that this does not refresh the data from GTFS-Realtime feeds, it only fetches what is stored in the database. In order to fetch the latest service alerts from GTFS-Realtime feeds and store in your database, use the [GTFS-Realtime update script or function](#gtfsrealtime-update-script).
+Returns an array of GTFS Realtime service alerts that match query parameters. Each alert includes a nested `informed_entities` array containing all related informed entities (stops, routes, trips) that the alert applies to. Note that this does not refresh the data from GTFS-Realtime feeds, it only fetches what is stored in the database. In order to fetch the latest service alerts from GTFS-Realtime feeds and store in your database, use the [GTFS-Realtime update script or function](#gtfsrealtime-update-script).
 
 [More details on Service Alerts](https://gtfs.org/realtime/feed-entities/service-alerts/)
 
@@ -1538,6 +1538,22 @@ import { getServiceAlerts } from 'gtfs';
 
 // Get service alerts
 const serviceAlerts = getServiceAlerts();
+```
+
+#### getServiceAlertInformedEntities(query, fields, sortBy, options)
+
+Returns an array of GTFS Realtime service alert informed entities that match query parameters. Each row represents a single entity (stop, route, trip, etc.) that a service alert applies to, linked back to its alert via `alert_id`. Use this for direct access to the `service_alert_informed_entities` table; use `getServiceAlerts()` to get alerts with all informed entities already nested.
+
+[More details on Service Alert Informed Entities](https://gtfs.org/realtime/feed-entities/service-alerts/#entityselector)
+
+```js
+import { getServiceAlertInformedEntities } from 'gtfs';
+
+// Get all service alert informed entities
+const informedEntities = getServiceAlertInformedEntities();
+
+// Get all informed entities for a specific alert
+const informedEntities = getServiceAlertInformedEntities({ alert_id: 'some-alert-id' });
 ```
 
 #### getTripUpdates(query, fields, sortBy, options)

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,6 +89,7 @@ export { getStopTimeUpdates } from './lib/gtfs-realtime/stop-time-updates.ts';
 export { getTripUpdates } from './lib/gtfs-realtime/trip-updates.ts';
 export { getVehiclePositions } from './lib/gtfs-realtime/vehicle-positions.ts';
 export { getServiceAlerts } from './lib/gtfs-realtime/service-alerts.ts';
+export { getServiceAlertInformedEntities } from './lib/gtfs-realtime/service-alert-informed-entities.ts';
 
 // ODS
 export { getDeadheads } from './lib/ods/deadheads.ts';

--- a/src/lib/gtfs-realtime/service-alert-informed-entities.ts
+++ b/src/lib/gtfs-realtime/service-alert-informed-entities.ts
@@ -1,0 +1,37 @@
+import type {
+  QueryOptions,
+  SqlOrderBy,
+  QueryResult,
+  SqlWhere,
+  ServiceAlertInformedEntity,
+} from '../../types/global_interfaces.ts';
+import { openDb } from '../db.ts';
+import {
+  formatOrderByClause,
+  formatSelectClause,
+  formatWhereClauses,
+} from '../utils.ts';
+
+/*
+ * Returns an array of all service alert informed entities that match the query parameters.
+ */
+export function getServiceAlertInformedEntities<
+  Fields extends keyof ServiceAlertInformedEntity,
+>(
+  query: SqlWhere = {},
+  fields: Fields[] = [],
+  orderBy: SqlOrderBy = [],
+  options: QueryOptions = {},
+) {
+  const db = options.db ?? openDb();
+  const tableName = 'service_alert_informed_entities';
+  const selectClause = formatSelectClause(fields);
+  const whereClause = formatWhereClauses(query);
+  const orderByClause = formatOrderByClause(orderBy);
+
+  return db
+    .prepare(
+      `${selectClause} FROM ${tableName} ${whereClause} ${orderByClause};`,
+    )
+    .all() as QueryResult<ServiceAlertInformedEntity, Fields>[];
+}

--- a/src/lib/gtfs-realtime/service-alerts.ts
+++ b/src/lib/gtfs-realtime/service-alerts.ts
@@ -1,9 +1,9 @@
 import type {
   QueryOptions,
   SqlOrderBy,
-  QueryResult,
   SqlWhere,
   ServiceAlert,
+  ServiceAlertInformedEntity,
 } from '../../types/global_interfaces.ts';
 import { openDb } from '../db.ts';
 import {
@@ -14,6 +14,8 @@ import {
 
 /*
  * Returns an array of all service alerts that match the query parameters.
+ * Each alert includes a nested `informed_entities` array containing all of
+ * its related informed entities.
  */
 export function getServiceAlerts<Fields extends keyof ServiceAlert>(
   query: SqlWhere = {},
@@ -28,9 +30,32 @@ export function getServiceAlerts<Fields extends keyof ServiceAlert>(
   const whereClause = formatWhereClauses(query);
   const orderByClause = formatOrderByClause(orderBy);
 
-  return db
+  const alerts = db
     .prepare(
-      `${selectClause} FROM ${tableName} INNER JOIN ${joinTableName} ON ${tableName}.id=${joinTableName}.alert_id ${whereClause} ${orderByClause};`,
+      `${selectClause} FROM ${tableName} ${whereClause} ${orderByClause};`,
     )
-    .all() as QueryResult<ServiceAlert, Fields>[];
+    .all() as Omit<ServiceAlert, 'informed_entities'>[];
+
+  const alertIds = alerts.map((alert) => alert.id);
+  const placeholders = alertIds.map(() => '?').join(', ');
+  const entities = db
+    .prepare(
+      `SELECT * FROM ${joinTableName} WHERE alert_id IN (${placeholders});`,
+    )
+    .all(...alertIds) as ServiceAlertInformedEntity[];
+
+  const entitiesByAlertId = new Map<string, ServiceAlertInformedEntity[]>();
+  for (const entity of entities) {
+    const group = entitiesByAlertId.get(entity.alert_id);
+    if (group) {
+      group.push(entity);
+    } else {
+      entitiesByAlertId.set(entity.alert_id, [entity]);
+    }
+  }
+
+  return alerts.map((alert) => ({
+    ...alert,
+    informed_entities: entitiesByAlertId.get(alert.id) ?? [],
+  }));
 }

--- a/src/lib/import-gtfs-realtime.ts
+++ b/src/lib/import-gtfs-realtime.ts
@@ -271,6 +271,10 @@ function createServiceAlertsProcessor(
     models.serviceAlertInformedEntities as Model,
   );
 
+  const deleteInformedEntitiesStmt = db.prepare(
+    `DELETE FROM ${models.serviceAlertInformedEntities.filenameBase} WHERE alert_id = ?`,
+  );
+
   return async (batch: ProcessedEntity[]): Promise<ProcessingResult> => {
     let recordCount = 0;
     let errorCount = 0;
@@ -284,6 +288,12 @@ function createServiceAlertsProcessor(
           ).map((column) => prepareRealtimeFieldValue(entity, column, task));
           alertStmt.run(alertValues);
           recordCount++;
+
+          // Replace this alert's informed entities. Delete the existing set
+          // (matching on the same prefixed alert_id the inserts use) before
+          // re-inserting, so refreshes don't accumulate duplicate rows.
+          const alertId = applyPrefixToValue(entity.id, true, task.prefix);
+          deleteInformedEntitiesStmt.run(alertId);
 
           // Process informed entities
           if (entity.alert?.informedEntity?.length) {

--- a/src/models/gtfs-realtime/service-alert-informed_entities.ts
+++ b/src/models/gtfs-realtime/service-alert-informed_entities.ts
@@ -6,7 +6,7 @@ export const serviceAlertInformedEntities = {
       name: 'alert_id',
       type: 'text',
       required: true,
-      primary: true,
+      index: true,
       source: 'parent.id',
       prefix: true,
     },

--- a/src/test/get-service-alerts.test.ts
+++ b/src/test/get-service-alerts.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, beforeAll, afterAll, expect } from './test-utils.ts';
+import { createServer, type Server } from 'node:http';
+import GtfsRealtimeBindings from 'gtfs-realtime-bindings';
+
+import config from './test-config.ts';
+import {
+  type Config,
+  openDb,
+  closeDb,
+  importGtfs,
+  updateGtfsRealtime,
+  getServiceAlerts,
+} from '../../dist/index.js';
+
+const ALERT_ID = 'test-alert-1';
+
+/*
+ * Builds an encoded GTFS-Realtime FeedMessage protobuf payload containing a
+ * single service alert with three informed entities, one of which is a
+ * route-only entity (stop_id and trip_id are NULL) to exercise the NULL path.
+ */
+function buildAlertFeedBuffer(): Buffer {
+  const { transit_realtime } = GtfsRealtimeBindings;
+
+  const message = transit_realtime.FeedMessage.fromObject({
+    header: {
+      gtfsRealtimeVersion: '2.0',
+      timestamp: Math.floor(Date.now() / 1000),
+    },
+    entity: [
+      {
+        id: ALERT_ID,
+        alert: {
+          activePeriod: [{ start: 1000, end: 2000 }],
+          headerText: { translation: [{ text: 'Test alert header' }] },
+          descriptionText: {
+            translation: [{ text: 'Test alert description' }],
+          },
+          informedEntity: [
+            // Stop + route specific entity
+            { stopId: 'stop-A', routeId: 'route-1' },
+            // Trip + route_type specific entity
+            { trip: { tripId: 'trip-9' }, routeType: 3 },
+            // Route-only entity (stop_id and trip_id are NULL)
+            { routeId: 'route-7' },
+          ],
+        },
+      },
+    ],
+  });
+
+  return Buffer.from(transit_realtime.FeedMessage.encode(message).finish());
+}
+
+describe('getServiceAlerts():', () => {
+  let server: Server;
+  let realtimeConfig: Config;
+
+  beforeAll(async () => {
+    const feedBuffer = buildAlertFeedBuffer();
+
+    server = createServer((request, response) => {
+      response.writeHead(200, { 'Content-Type': 'application/octet-stream' });
+      response.end(feedBuffer);
+    });
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, '127.0.0.1', resolve);
+    });
+
+    const { port } = server.address() as { port: number };
+
+    realtimeConfig = {
+      ...config,
+      // Use a long expiration so rows are not removed by the expiry sweep
+      // between polls — this forces the no-duplicates behavior to rely on the
+      // per-alert delete rather than on expiration cleanup.
+      gtfsRealtimeExpirationSeconds: 3600,
+      sqlitePath: ':memory:',
+      agencies: [
+        {
+          ...config.agencies[0],
+          realtimeAlerts: {
+            url: `http://127.0.0.1:${port}/alerts`,
+          },
+        },
+      ],
+    };
+
+    openDb(realtimeConfig);
+    // Fresh import to (re)create tables with the current schema.
+    await importGtfs(realtimeConfig);
+  });
+
+  afterAll(async () => {
+    const db = openDb(realtimeConfig);
+    closeDb(db);
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  });
+
+  it('should return one alert with nested informed_entities', async () => {
+    await updateGtfsRealtime(realtimeConfig);
+
+    const results = getServiceAlerts({ id: ALERT_ID });
+
+    // One alert object, not one row per informed entity
+    expect(results).toHaveLength(1);
+
+    const alert = results[0];
+    expect(alert.id).toBe(ALERT_ID);
+    expect(alert.header_text).toBe('Test alert header');
+    expect(alert.description_text).toBe('Test alert description');
+
+    // All three informed entities nested under the alert
+    expect(alert.informed_entities).toHaveLength(3);
+
+    const stopRouteEntity = alert.informed_entities.find(
+      (e) => e.stop_id === 'stop-A',
+    );
+    expect(stopRouteEntity).toBeDefined();
+    expect(stopRouteEntity?.route_id).toBe('route-1');
+
+    const tripEntity = alert.informed_entities.find(
+      (e) => e.trip_id === 'trip-9',
+    );
+    expect(tripEntity).toBeDefined();
+    expect(tripEntity?.route_type).toBe(3);
+
+    const routeOnlyEntity = alert.informed_entities.find(
+      (e) =>
+        e.route_id === 'route-7' && e.stop_id === null && e.trip_id === null,
+    );
+    expect(routeOnlyEntity).toBeDefined();
+  });
+
+  it('should not accumulate duplicate results across refreshes', async () => {
+    // Simulate a second refresh poll of the same feed.
+    await updateGtfsRealtime(realtimeConfig);
+
+    const results = getServiceAlerts({ id: ALERT_ID });
+
+    // Still one alert with exactly three informed entities
+    expect(results).toHaveLength(1);
+    expect(results[0].informed_entities).toHaveLength(3);
+  });
+});

--- a/src/types/global_interfaces.ts
+++ b/src/types/global_interfaces.ts
@@ -653,6 +653,17 @@ export interface RunPiece {
   end_trip_position: number | null;
 }
 
+export interface ServiceAlertInformedEntity {
+  alert_id: string;
+  stop_id: string | null;
+  route_id: string | null;
+  route_type: number | null;
+  trip_id: string | null;
+  direction_id: number | null;
+  created_timestamp: UnixTimestamp;
+  expiration_timestamp: UnixTimestamp;
+}
+
 export interface ServiceAlert {
   id: string;
   cause: string | null;
@@ -667,6 +678,7 @@ export interface ServiceAlert {
   severity_level: string | null;
   created_timestamp: UnixTimestamp;
   expiration_timestamp: UnixTimestamp;
+  informed_entities: ServiceAlertInformedEntity[];
 }
 
 export interface StopTimeUpdate {


### PR DESCRIPTION
Hey, thanks so much for this repo -- we're big fans at LA Metro!

We've been experimenting with [a new series of rider tools](https://github.com/LACMTA/ride-metro-net) using this library, and have recently been exploring using the `GTFS-rt` functionality.

In the process, I believe we've found a bug: service alerts with multiple `informed_entity` entries only persist one of them. 

The cause appears to be that `service_alert_informed_entities` uses a single-column primary key on `alert_id` combined with `REPLACE INTO`, so each entity overwrites the previous one when the `rt` data is updated, leaving a maximum of one informed entity per alert.

This PR attempts to resolve that in the following ways:
- Removes the primary key on `informed_entities` to allow a one-to-many relationship between `service_alerts` and `informed_entities` 
- Implements an explicit delete-then-insert pattern for `informed_entities` to ensure deduplication. 
- Updates `getServiceAlerts()` to return a nested array of `informed_entities`
- Adds `getServiceAlertInformedEntities()` for directly querying `informed_entities`
- Adds the `ServiceAlertInformedEntity` type, and updates the `ServiceAlert` type to include nested `informed_entities` 
- Adds a test for `getServiceAlerts()`
- Updates the `README` to reflect these changes.

Happy to discuss any of this. In particular, the changes to the database schema and `getServiceAlerts()` could constitute breaking changes, so I'm more than happy to revise if there's a better approach.