### PR TITLE
Fix getShapesAsGeoJSON returning reversed shape coordinates

### DIFF
--- a/src/lib/geojson-utils.ts
+++ b/src/lib/geojson-utils.ts
@@ -77,7 +77,9 @@ function consolidateShapes(shapeGroups: Shape[][]): Position[][] {
 
     for (const segment of segments) {
       const key1 = segment.flat().join(',');
-      const key2 = segment.reverse().flat().join(',');
+      // Copy before reversing: `segment` is reused below to build the line, so
+      // reversing it in place flips each point's order.
+      const key2 = [...segment].reverse().flat().join(',');
       const currentLine = last(consolidatedLineStrings);
 
       if (!currentLine || keys.has(key1) || keys.has(key2)) {

--- a/src/test/get-shapes-as-geojson.test.ts
+++ b/src/test/get-shapes-as-geojson.test.ts
@@ -101,6 +101,11 @@ describe('getShapesAsGeoJSON():', () => {
       (geojson.features[0].geometry as GeoJSON.MultiLineString)
         .coordinates[0][0],
     ).toHaveLength(2);
+    // The line must start at the shape's first point, in order.
+    expect(
+      (geojson.features[0].geometry as GeoJSON.MultiLineString)
+        .coordinates[0][0],
+    ).toEqual([-122.39441156387329, 37.776439059278346]);
     expect(geojson.features[0].properties?.route_color).toMatch(/^#/);
   });
 });


### PR DESCRIPTION
While using `getShapesAsGeoJSON()` I noticed the returned line geometry was off — the coordinates come back reordered, with a point duplicated and the last one dropped, so the line doesn't trace the actual shape.

It's in `consolidateShapes` (src/lib/geojson-utils.ts). When it builds the direction-agnostic dedupe key it calls `segment.reverse()`, which reverses `segment` in place. That same `segment` is then used just below (`segment[0]`, `segment[1]`) to append points to the line, so every segment ends up added in reverse.

For a shape `[P0, P1, P2, P3]` you get `[P1, P0, P1, P2]` instead of `[P0, P1, P2, P3]`. The existing tests only asserted the coordinate array *length*, which the bug preserves, so it wasn't caught.

The fix copies the segment before reversing it for the key. I added an ordering assertion to the `cal_sf_tam` shape test (fails before, passes after); the full suite still passes.