### PR TITLE
Add agency_id's to service alert informed entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1546,11 +1546,11 @@ In order to use GTFS-Realtime query methods, you must first run the [GTFS-Realti
 
 #### getServiceAlerts(query, fields, sortBy, options)
 
-Returns an array of GTFS Realtime service alerts that match query parameters. Each alert includes a nested `informed_entities` array containing all related informed entities (stops, routes, trips) that the alert applies to. Note that this does not refresh the data from GTFS-Realtime feeds, it only fetches what is stored in the database. In order to fetch the latest service alerts from GTFS-Realtime feeds and store in your database, use the [GTFS-Realtime update script or function](#gtfsrealtime-update-script).
+Returns an array of GTFS Realtime service alerts that match query parameters. Each alert includes a nested `informed_entities` array containing all related informed entities (agencies, stops, routes, trips) that the alert applies to. Note that this does not refresh the data from GTFS-Realtime feeds, it only fetches what is stored in the database. In order to fetch the latest service alerts from GTFS-Realtime feeds and store in your database, use the [GTFS-Realtime update script or function](#gtfsrealtime-update-script).
 
 [More details on Service Alerts](https://gtfs.org/realtime/feed-entities/service-alerts/)
 
-Each alert has an `informed_entities` array containing all stops, routes, and trips the alert applies to. The `active_period` field is a JSON-serialised array of `{start, end}` Unix timestamp objects representing when the alert is active. The convenience fields `start_time` and `end_time` contain the start and end of the first active period (or `null` if none is set).
+Each alert has an `informed_entities` array containing all agencies, stops, routes, and trips the alert applies to. The `active_period` field is a JSON-serialised array of `{start, end}` Unix timestamp objects representing when the alert is active. The convenience fields `start_time` and `end_time` contain the start and end of the first active period (or `null` if none is set).
 
 ```js
 import { getServiceAlerts } from 'gtfs';
@@ -1567,7 +1567,7 @@ const routeAlerts = getServiceAlerts({ route_id: 'ROUTE_ID' });
 
 #### getServiceAlertInformedEntities(query, fields, sortBy, options)
 
-Returns an array of GTFS Realtime service alert informed entities that match query parameters. Each row represents a single entity (stop, route, trip, etc.) that a service alert applies to, linked back to its alert via `alert_id`. Use this for direct access to the `service_alert_informed_entities` table; use `getServiceAlerts()` to get alerts with all informed entities already nested.
+Returns an array of GTFS Realtime service alert informed entities that match query parameters. Each row represents a single entity (agency, stop, route, trip, etc.) that a service alert applies to, linked back to its alert via `alert_id`. Use this for direct access to the `service_alert_informed_entities` table; use `getServiceAlerts()` to get alerts with all informed entities already nested.
 
 [More details on Service Alert Informed Entities](https://gtfs.org/realtime/feed-entities/service-alerts/#entityselector)
 

--- a/src/lib/gtfs-realtime/service-alerts.ts
+++ b/src/lib/gtfs-realtime/service-alerts.ts
@@ -17,6 +17,7 @@ import {
 // alerts query — otherwise SQLite throws "no such column".
 const ENTITY_COLUMNS = new Set([
   'alert_id',
+  'agency_id',
   'stop_id',
   'route_id',
   'route_type',

--- a/src/models/gtfs-realtime/service-alert-informed_entities.ts
+++ b/src/models/gtfs-realtime/service-alert-informed_entities.ts
@@ -11,6 +11,14 @@ export const serviceAlertInformedEntities = {
       prefix: true,
     },
     {
+      name: 'agency_id',
+      type: 'text',
+      primary: true,
+      source: 'agencyId',
+      default: null,
+      prefix: true,
+    },
+    {
       name: 'stop_id',
       type: 'text',
       primary: true,

--- a/src/test/get-service-alerts.test.ts
+++ b/src/test/get-service-alerts.test.ts
@@ -16,8 +16,9 @@ const ALERT_ID = 'test-alert-1';
 
 /*
  * Builds an encoded GTFS-Realtime FeedMessage protobuf payload containing a
- * single service alert with three informed entities, one of which is a
- * route-only entity (stop_id and trip_id are NULL) to exercise the NULL path.
+ * single service alert with four informed entities, one of which is a
+ * route-only entity (stop_id and trip_id are NULL) to exercise the NULL path
+ * and one of which is an agency-wide entity (only agency_id is set).
  */
 function buildAlertFeedBuffer(): Buffer {
   const { transit_realtime } = GtfsRealtimeBindings;
@@ -43,6 +44,8 @@ function buildAlertFeedBuffer(): Buffer {
             { trip: { tripId: 'trip-9' }, routeType: 3 },
             // Route-only entity (stop_id and trip_id are NULL)
             { routeId: 'route-7' },
+            // Agency-wide entity (no stop/route/trip)
+            { agencyId: 'agency-1' },
           ],
         },
       },
@@ -113,8 +116,8 @@ describe('getServiceAlerts():', () => {
     expect(alert.header_text).toBe('Test alert header');
     expect(alert.description_text).toBe('Test alert description');
 
-    // All three informed entities nested under the alert
-    expect(alert.informed_entities).toHaveLength(3);
+    // All four informed entities nested under the alert
+    expect(alert.informed_entities).toHaveLength(4);
 
     const stopRouteEntity = alert.informed_entities.find(
       (e) => e.stop_id === 'stop-A',
@@ -133,6 +136,14 @@ describe('getServiceAlerts():', () => {
         e.route_id === 'route-7' && e.stop_id === null && e.trip_id === null,
     );
     expect(routeOnlyEntity).toBeDefined();
+
+    const agencyEntity = alert.informed_entities.find(
+      (e) => e.agency_id === 'agency-1',
+    );
+    expect(agencyEntity).toBeDefined();
+    expect(agencyEntity?.stop_id).toBeNull();
+    expect(agencyEntity?.route_id).toBeNull();
+    expect(agencyEntity?.trip_id).toBeNull();
   });
 
   it('should not accumulate duplicate results across refreshes', async () => {
@@ -141,8 +152,8 @@ describe('getServiceAlerts():', () => {
 
     const results = getServiceAlerts({ id: ALERT_ID });
 
-    // Still one alert with exactly three informed entities
+    // Still one alert with exactly four informed entities
     expect(results).toHaveLength(1);
-    expect(results[0].informed_entities).toHaveLength(3);
+    expect(results[0].informed_entities).toHaveLength(4);
   });
 });

--- a/src/types/global_interfaces.ts
+++ b/src/types/global_interfaces.ts
@@ -655,6 +655,7 @@ export interface RunPiece {
 
 export interface ServiceAlertInformedEntity {
   alert_id: string;
+  agency_id: string | null;
   stop_id: string | null;
   route_id: string | null;
   route_type: number | null;


### PR DESCRIPTION
Hi again!

Currently, the `service_alert_informed_entities` table does not include an `agency_id` column, even though this is a valid entity in [the spec](https://gtfs.org/documentation/realtime/reference/#message-entityselector). This is fine for most cases, but if data from multiple agencies is being consumed, it leads to a situation where a system-wide alerts (eg, where the _only_ informed entity is the agency) cannot be reconciled back to which agency issued them.

This PR:
* Adds the `agency_id` column to `service_alert_informed_entities`
* Adds a test case relying on this column

Thanks!